### PR TITLE
migrate to null safety

### DIFF
--- a/lib/favicon.dart
+++ b/lib/favicon.dart
@@ -42,7 +42,7 @@ class Icon implements Comparable<Icon> {
 }
 
 class Favicon {
-  static Future<List<Icon>> getAll(String url, {List<String> suffixes}) async {
+  static Future<List<Icon>> getAll(String url, {List<String>? suffixes}) async {
     var favicons = <Icon>[];
     var iconUrls = <String>[];
 
@@ -52,8 +52,8 @@ class Favicon {
     // Look for icons in tags
     for (var rel in ['icon', 'shortcut icon']) {
       for (var iconTag in document.querySelectorAll("link[rel='$rel']")) {
-        if (iconTag != null && iconTag.attributes['href'] != null) {
-          var iconUrl = iconTag.attributes['href'].trim();
+        if (iconTag.attributes['href'] != null) {
+          var iconUrl = iconTag.attributes['href']!.trim();
 
           // Fix scheme relative URLs
           if (iconUrl.startsWith('//')) {
@@ -119,7 +119,7 @@ class Favicon {
     return favicons..sort();
   }
 
-  static Future<Icon> getBest(String url, {List<String> suffixes}) async {
+  static Future<Icon?> getBest(String url, {List<String>? suffixes}) async {
     List<Icon> favicons = await getAll(url, suffixes: suffixes);
     return favicons.isNotEmpty ? favicons.first : null;
   }
@@ -142,7 +142,7 @@ class Favicon {
     }
 
     return response.statusCode == 200 &&
-        response.contentLength > 0 &&
+        (response.contentLength ?? 0) > 0 &&
         contentType.contains('image');
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.14
 homepage: https://github.com/marcjoha/favicon
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.0


### PR DESCRIPTION
I migrated to null safety, this library.

May be some apis should be refactored, but I modified minimum code.

fix marcjoha/favicon#3
