### PR TITLE
Add Function to Validate Domain in URLs

### DIFF
--- a/lib/favicon.dart
+++ b/lib/favicon.dart
@@ -46,7 +46,7 @@ class FaviconFinder {
     String url, {
     List<String>? suffixes,
   }) async {
-    if (!_verifyDomain(url)) {
+    if (!verifyDomain(url)) {
       throw ArgumentError('Invalid URL');
     }
 
@@ -141,7 +141,7 @@ class FaviconFinder {
   /// method will return [false].
   ///
   /// Returns [true] if the URL has a valid domain, otherwise returns [false].
-  static bool _verifyDomain(String url) {
+  static bool verifyDomain(String url) {
     try {
       var uri = Uri.parse(url);
 

--- a/lib/favicon.dart
+++ b/lib/favicon.dart
@@ -46,6 +46,10 @@ class FaviconFinder {
     String url, {
     List<String>? suffixes,
   }) async {
+    if (!_verifyDomain(url)) {
+      throw ArgumentError('Invalid URL');
+    }
+
     var favicons = <Favicon>[];
     var iconUrls = <String>[];
 
@@ -115,8 +119,7 @@ class FaviconFinder {
 
       var image = decodeImage((await http.get(Uri.parse(iconUrl))).bodyBytes);
       if (image != null) {
-        favicons
-            .add(Favicon(iconUrl, width: image.width, height: image.height));
+        favicons.add(Favicon(iconUrl, width: image.width, height: image.height));
       }
     }
 
@@ -126,6 +129,35 @@ class FaviconFinder {
   static Future<Favicon?> getBest(String url, {List<String>? suffixes}) async {
     List<Favicon> favicons = await getAll(url, suffixes: suffixes);
     return favicons.isNotEmpty ? favicons.first : null;
+  }
+
+  /// Verifies if the given URL has a valid domain.
+  ///
+  /// This method checks if the URL has a valid scheme (either 'http' or 'https')
+  /// and if the domain follows a specific pattern. The domain pattern is checked
+  /// using a regular expression.
+  ///
+  /// If the URL parsing or domain pattern matching throws an exception, this
+  /// method will return [false].
+  ///
+  /// Returns [true] if the URL has a valid domain, otherwise returns [false].
+  static bool _verifyDomain(String url) {
+    try {
+      var uri = Uri.parse(url);
+
+      // Verify the scheme (must be either 'http' or 'https')
+      if (uri.scheme != 'http' && uri.scheme != 'https') {
+        return false;
+      }
+
+      // Check the domain pattern using a regular expression
+      var domainPattern = RegExp(
+          r'^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9]+[a-zA-Z0-9-]+[a-zA-Z0-9]))(\.([a-zA-Z]{2,})+)+$');
+      return domainPattern.hasMatch(uri.host);
+    } catch (e) {
+      // Return false if an exception occurs during URL parsing or domain pattern matching
+      return false;
+    }
   }
 
   static Future<bool> _verifyImage(String url) async {


### PR DESCRIPTION
# Overview
This Pull Request introduces a new utility function, `verifyDomain`, designed to validate the domain within a given URL. This function ensures that the URL not only conforms to the standard URL format but also checks that the domain part of the URL is valid as per the typical domain naming conventions.

# Implementation Details

The function isValidDomain takes a string input, which is expected to be a URL.
It first parses the URL using Dart's Uri.parse method.
Validates that the URL's scheme is either http or https.
Applies a regular expression to validate the domain format. This regex checks for common domain naming patterns and is designed to be robust enough to handle a wide variety of valid domains.
The function returns a boolean value indicating the validity of the domain.

# Error Handling

The function is wrapped in a try-catch block to gracefully handle any exceptions that might occur during the URL parsing process, returning false in case of an error.

# Use Case
This function is particularly useful in scenarios where validating the integrity of a URL is crucial, such as when processing web links, ensuring valid input in forms, or dealing with external URLs in a secure manner.